### PR TITLE
Fix blocking stdin.read() loop when no data available

### DIFF
--- a/espmonitor/src/lib.rs
+++ b/espmonitor/src/lib.rs
@@ -274,18 +274,19 @@ fn reset_chip(dev: &mut SerialStream) -> io::Result<()> {
 
 fn handle_stdin(reader: &mut SerialReader) -> io::Result<()> {
     let mut buf = [0; 32];
-    match io::stdin().read(&mut buf)? {
-        bytes if bytes > 0 => {
-            for b in buf[0..bytes].iter() {
-                #[allow(clippy::single_match)]
-                match *b {
-                    RESET_KEYCODE => reset_chip(&mut reader.dev)?,
-                    _ => (),
+    loop {
+        match io::stdin().read(&mut buf)? {
+            bytes if bytes > 0 => {
+                for b in buf[0..bytes].iter() {
+                    #[allow(clippy::single_match)]
+                    match *b {
+                        RESET_KEYCODE => reset_chip(&mut reader.dev)?,
+                        _ => (),
+                    }
                 }
-            }
-            Ok(())
-        },
-        _ => Ok(()),
+            },
+            _ => return Ok(()),
+        }
     }
 }
 

--- a/espmonitor/src/lib.rs
+++ b/espmonitor/src/lib.rs
@@ -274,19 +274,18 @@ fn reset_chip(dev: &mut SerialStream) -> io::Result<()> {
 
 fn handle_stdin(reader: &mut SerialReader) -> io::Result<()> {
     let mut buf = [0; 32];
-    loop {
-        match io::stdin().read(&mut buf)? {
-            bytes if bytes > 0 => {
-                for b in buf[0..bytes].iter() {
-                    #[allow(clippy::single_match)]
-                    match *b {
-                        RESET_KEYCODE => reset_chip(&mut reader.dev)?,
-                        _ => (),
-                    }
+    match io::stdin().read(&mut buf)? {
+        bytes if bytes > 0 => {
+            for b in buf[0..bytes].iter() {
+                #[allow(clippy::single_match)]
+                match *b {
+                    RESET_KEYCODE => reset_chip(&mut reader.dev)?,
+                    _ => (),
                 }
-            },
-            _ => return Ok(()),
-        }
+            }
+            Ok(())
+        },
+        _ => Ok(()),
     }
 }
 

--- a/espmonitor/src/lib.rs
+++ b/espmonitor/src/lib.rs
@@ -18,7 +18,6 @@
 use lazy_static::lazy_static;
 use mio::{Interest, Poll, Token, event::Events};
 use mio_serial::{SerialPort, SerialPortBuilderExt, SerialStream};
-use nix::fcntl::{fcntl, FcntlArg::{F_GETFL, F_SETFL}, OFlag};
 use regex::Regex;
 use std::{ffi::OsString, ffi::OsStr, path::Path, process::Stdio, time::Instant};
 use std::io::{self, Error as IoError, ErrorKind, Read, Write};
@@ -224,6 +223,7 @@ fn run_child(mut args: AppArgs) -> Result<(), Box<dyn std::error::Error>> {
     poll.registry().register(&mut dev, SERIAL, Interest::READABLE)?;
     #[cfg(unix)]
     {
+        use nix::fcntl::{fcntl, FcntlArg::{F_GETFL, F_SETFL}, OFlag};
         let flags = OFlag::O_NONBLOCK |
             OFlag::from_bits(fcntl(0, F_GETFL)?).ok_or("F_GETFL returned invalid bits")?;
         fcntl(0, F_SETFL(flags))?;


### PR DESCRIPTION
It appears that stdin().read() may block indefinitely if no data is available, instead of returning Err. Just loop over what's available in
stdin, then return to polling.

(See #2).