### PR TITLE
Improve the error message in Chip::from_target()

### DIFF
--- a/espmonitor/src/types.rs
+++ b/espmonitor/src/types.rs
@@ -75,7 +75,7 @@ impl Chip {
         } else if target.contains("-esp8266-") {
             Ok(Chip::ESP8266)
         } else {
-            Err(IoError::new(ErrorKind::InvalidInput, format!("Can't figure out chip from target '{}'", target)))
+            Err(IoError::new(ErrorKind::InvalidInput, format!("Can't figure out chip from target '{}'; try specifying the --chip option", target)))
         }
     }
 }


### PR DESCRIPTION
ESP32-C3 is a more generic-ish RISC-V target, so it may not be safe to blindly assume that chip.