### PR TITLE
Use addr2line crate rather than shelling out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,12 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
 dependencies = [
+ "cpp_demangle",
+ "fallible-iterator",
  "gimli",
+ "object",
+ "rustc-demangle",
+ "smallvec",
 ]
 
 [[package]]
@@ -90,6 +95,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea47428dc9d2237f3c6bc134472edfd63ebba0af932e783506dcfd66f10d18a"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,9 +141,12 @@ dependencies = [
 name = "espmonitor"
 version = "0.5.3-alpha.1"
 dependencies = [
+ "addr2line",
  "crossterm",
+ "gimli",
  "lazy_static",
  "nix",
+ "object",
  "pico-args",
  "regex",
  "serial",
@@ -149,16 +175,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "flate2"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+dependencies = [
+ "cfg-if",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "gimli"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "indexmap"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
 
 [[package]]
 name = "instant"
@@ -283,6 +348,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
 dependencies = [
+ "flate2",
  "memchr",
 ]
 
@@ -476,6 +542,12 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"

--- a/espmonitor/Cargo.toml
+++ b/espmonitor/Cargo.toml
@@ -28,8 +28,11 @@ path = "src/main.rs"
 [lib]
 
 [dependencies]
+addr2line = "0.16"
 crossterm = "0.22"
+gimli = "0.25"
 lazy_static = "1"
+object = "0.26"
 pico-args = "0.4"
 regex = "1"
 serial = "0.4"

--- a/espmonitor/src/types.rs
+++ b/espmonitor/src/types.rs
@@ -102,15 +102,6 @@ impl Chip {
         });
         target
     }
-
-    pub fn tool_prefix(&self) -> &'static str {
-        match self {
-            Chip::ESP32 => "xtensa-esp32-elf-",
-            Chip::ESP32S2 => "xtensa-esp32s2-elf-",
-            Chip::ESP8266 => "xtensa-esp8266-elf-",
-            Chip::ESP32C3 => "riscv32imc-unknown-none-elf-",
-        }
-    }
 }
 
 impl TryFrom<&str> for Chip {


### PR DESCRIPTION
This partially addresses #5; we're now using the `addr2line` crate.  We may still want to change the formatting, or at least add some color, but we can tackle that in another PR.