### PR TITLE
Enable ANSI support in standalone espmonitor on Windows

### DIFF
--- a/espmonitor/src/main.rs
+++ b/espmonitor/src/main.rs
@@ -21,6 +21,10 @@ use std::convert::TryFrom;
 use std::error::Error;
 
 fn main() {
+    #[cfg(windows)]
+    let _ = crossterm::ansi_support::supports_ansi();
+    // supports_ansi() returns what it suggests, and as a side effect enables ANSI support
+
     match parse_args().and_then(|args| args.map(run).unwrap_or(Ok(()))) {
         Ok(_) => (),
         Err(err) => {


### PR DESCRIPTION
Before: 
![psbefore](https://user-images.githubusercontent.com/1284317/149232248-2094b6e7-fc0c-499e-a5c0-508ebeac12be.png)

After:
![psafter](https://user-images.githubusercontent.com/1284317/149232263-4a08b6d3-5741-497e-a899-72e637fc4bd9.png)

(those are two different runs, despite matching timestamps)

See: https://github.com/crossterm-rs/crossterm/blob/master/src/ansi_support.rs

This isn't necessary for `cargo-espmonitor` because Cargo already does it via `termcolor`.