### PR TITLE
Retry when interrupted syscall

### DIFF
--- a/espmonitor/src/lib.rs
+++ b/espmonitor/src/lib.rs
@@ -159,6 +159,7 @@ fn run_child(args: AppArgs) -> Result<(), Box<dyn std::error::Error>> {
             },
             Err(err) if err.kind() == ErrorKind::TimedOut => (),
             Err(err) if err.kind() == ErrorKind::WouldBlock => (),
+            Err(err) if err.kind() == ErrorKind::Interrupted => (),
             Err(err) => break Err(err.into()),
         }
 


### PR DESCRIPTION
On my system running espmonitor inside docker, sometimes the read from serial device will return interrupted syscall.

I am not sure why this happens but the docs stated `Interrupted operations can typically be retried.` so I guess we can safely retry the operation.