### PR TITLE
clap: Add `clap` support to espmonitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,8 +74,8 @@ name = "cargo-espmonitor"
 version = "0.7.1-alpha.1"
 dependencies = [
  "cargo-project",
+ "clap",
  "espmonitor",
- "pico-args",
 ]
 
 [[package]]
@@ -436,12 +436,6 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
-
-[[package]]
-name = "pico-args"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "proc-macro-error"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +106,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "cpp_demangle"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,12 +192,12 @@ name = "espmonitor"
 version = "0.7.1-alpha.1"
 dependencies = [
  "addr2line",
+ "clap",
  "crossterm",
  "gimli",
  "lazy_static",
  "nix",
  "object",
- "pico-args",
  "regex",
  "serial",
 ]
@@ -214,6 +264,21 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "indexmap"
@@ -344,6 +409,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +442,30 @@ name = "pico-args"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -539,6 +634,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termios"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +679,12 @@ checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "toml"
@@ -584,6 +700,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -606,6 +728,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/cargo-espmonitor/Cargo.toml
+++ b/cargo-espmonitor/Cargo.toml
@@ -25,4 +25,4 @@ keywords = [
 [dependencies]
 cargo-project = "0.2"
 espmonitor = { version = "^0.7.1-alpha.1", path = "../espmonitor" }
-pico-args = "0.4"
+clap = { version = "3.1", features = ["derive"] }

--- a/espmonitor/Cargo.toml
+++ b/espmonitor/Cargo.toml
@@ -29,11 +29,11 @@ path = "src/main.rs"
 
 [dependencies]
 addr2line = "0.17"
+clap = { version = "3.1", features = ["derive"] }
 crossterm = "0.23"
 gimli = "0.26"
 lazy_static = "1"
 object = "0.27"
-pico-args = "0.4"
 regex = "1"
 serial = "0.4"
 

--- a/espmonitor/src/lib.rs
+++ b/espmonitor/src/lib.rs
@@ -38,7 +38,6 @@ mod types;
 
 pub use types::{AppArgs, Chip, Framework};
 
-const DEFAULT_BAUD_RATE: BaudRate = BaudRate::Baud115200;
 const UNFINISHED_LINE_TIMEOUT: Duration = Duration::from_secs(5);
 
 lazy_static! {
@@ -119,7 +118,7 @@ fn run_child(args: AppArgs) -> Result<(), Box<dyn std::error::Error>> {
     rprintln!("    CTRL+C    Exit");
     rprintln!();
 
-    let speed = args.speed.map(BaudRate::from_speed).unwrap_or(DEFAULT_BAUD_RATE);
+    let speed = BaudRate::from_speed(args.speed);
     rprintln!("Opening {} with speed {}", args.serial, speed.speed());
 
     let mut dev = serial::open(&args.serial)?;

--- a/espmonitor/src/types.rs
+++ b/espmonitor/src/types.rs
@@ -15,13 +15,14 @@
 // You should have received a copy of the GNU General Public License
 // along with ESPMonitor.  If not, see <https://www.gnu.org/licenses/>.
 
+use clap::{ArgEnum, Parser};
 use std::{
     convert::TryFrom,
     ffi::OsString,
     io::{Error as IoError, ErrorKind},
 };
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, ArgEnum)]
 pub enum Framework {
     Baremetal,
     EspIdf,
@@ -57,7 +58,7 @@ impl Default for Framework {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, ArgEnum)]
 pub enum Chip {
     ESP32,
     ESP32S2,
@@ -122,12 +123,34 @@ impl Default for Chip {
     }
 }
 
-#[derive(Debug)]
+#[derive(Parser, Debug)]
+#[clap(author, version, about)]
 pub struct AppArgs {
-    pub serial: String,
+    /// Which ESP chip to target
+    #[clap(short, long, arg_enum, default_value_t = Chip::ESP32)]
     pub chip: Chip,
+
+    /// ???
+    #[clap(arg_enum, skip)]
     pub framework: Framework,
-    pub speed: Option<usize>,
+
+    /// Reset the chip on start
+    #[clap(short, long)]
     pub reset: bool,
+
+    /// Do not reset the chip on start
+    #[clap(long, conflicts_with("reset"))]
+    pub no_reset: bool,
+
+    /// Baud rate of serial device
+    #[clap(long, short, default_value = "115200", name = "BAUD")]
+    pub speed: usize,
+
+    /// Path to executable matching what is on the device
+    #[clap(long, short, name = "BINARY")]
     pub bin: Option<OsString>,
+
+    /// Path to the serial device
+    #[clap(name = "SERIAL_DEVICE")]
+    pub serial: String,
 }

--- a/espmonitor/src/types.rs
+++ b/espmonitor/src/types.rs
@@ -130,10 +130,6 @@ pub struct AppArgs {
     #[clap(short, long, arg_enum, default_value_t = Chip::ESP32)]
     pub chip: Chip,
 
-    /// ???
-    #[clap(arg_enum, skip)]
-    pub framework: Framework,
-
     /// Reset the chip on start
     #[clap(short, long)]
     pub reset: bool,


### PR DESCRIPTION
Replaces the current `pico_args` with `clap` to do command-line processing. This pulls in a bunch of additional dependencies but eases the CLI argument handling.

It also allows to define the default values for all configurations directly with the argument structure (e.g. for the serial baud rate).

**Note**: I have only implemented this for the `espmonitor`, not the cargo integration. If there is interest in this change I can add it there as well.

I did some basic testing and so far it seemed to work quite well. I'm still unhappy with the `Error: Invalid argument` when passing odd values such as 81251 to the serial baud rate, but I'm afraid that fixing this is outside of this projects scope.