### PR TITLE
Fix reset behavior

### DIFF
--- a/espmonitor/src/lib.rs
+++ b/espmonitor/src/lib.rs
@@ -31,6 +31,7 @@ use std::{
     fs,
     io::{self, stdout, ErrorKind, Read, Write},
     process::exit,
+    thread,
     time::{Duration, Instant},
 };
 
@@ -216,8 +217,8 @@ pub fn load_bin_context(data: &[u8]) -> Result<Symbols, Box<dyn std::error::Erro
 fn reset_chip(dev: &mut SystemPort) -> io::Result<()> {
     print!("Resetting device... ");
     std::io::stdout().flush()?;
-    dev.set_dtr(false)?;
     dev.set_rts(true)?;
+    thread::sleep(Duration::from_millis(200));
     dev.set_rts(false)?;
     rprintln!("done");
     Ok(())


### PR DESCRIPTION
Delays taken from https://github.com/espressif/esp-idf/blob/4eb98adf43c945e67db8eb6f89451e8c5964378a/tools/idf_monitor_base/chip_specific_config.py#L15-L37

Behavior matched with https://github.com/espressif/esp-idf/blob/4eb98adf43c945e67db8eb6f89451e8c5964378a/tools/idf_monitor_base/serial_handler.py#L195-L201

The original behavior seemed to work okay for UART connected devices; however with the S2 connected via CDC UART, the referenced behavior was required.